### PR TITLE
Fix colored log output

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -72,7 +72,7 @@ pub fn print_log(level: LogLevel, message: &str, params: LogParameters) -> Strin
     if level <= LogLevel::Warn {
         let name = format!("[{:?}] ", level).to_uppercase();
         match level.color() {
-            Some(c) if params.log_colors => output.push_str(&name.color(c)),
+            Some(c) if params.log_colors => write!(output, "{}", name.color(c)).unwrap(),
             _ => output.push_str(&name),
         }
     }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -70,14 +70,14 @@ pub fn print_log(level: LogLevel, message: &str, params: LogParameters) -> Strin
         write!(output, "{} ", (params.clock)().format("[%a %b %e %T %Y]")).unwrap();
     }
     if level <= LogLevel::Warn {
-        let name = format!("[{:?}] ", level).to_uppercase();
-        match level.color() {
-            Some(c) if params.log_colors => write!(output, "{}", name.color(c)).unwrap(),
-            _ => output.push_str(&name),
-        }
+        let prefix = format!("[{:?}] ", level).to_uppercase();
+        let prefix = match level.color() {
+            Some(c) if params.log_colors => format!("{}", prefix.color(c)),
+            _ => prefix,
+        };
+        write!(output, "{}", prefix).unwrap();
     }
-    output.push_str(message);
-    output.push('\n');
+    write!(output, "{}\n", message).unwrap();
     output
 }
 


### PR DESCRIPTION
Hi @mquander,

I noticed that log messages don't get colored.

After spending some time I found that it is mainly because of how we generate output string.
We use `push_str` which requires `&str` as a parameter. So, we have to use `&` and dereference occurs on `ColoredString` instance.

Due to [implementation](https://github.com/mackwic/colored/blob/master/src/lib.rs#L194) of `Deref` for `ColoredString` only  raw text gets returned (without any style attributes).

I tried to use `write!` and it worked.
I also decided to change another `push_str` usages to `write!` for consistency.

What do you think?

---

Currently on master:
![image](https://user-images.githubusercontent.com/11523473/32078015-fdfc3d26-baad-11e7-865a-d50aec17a8b9.png)

With this patch:
![image](https://user-images.githubusercontent.com/11523473/32077900-a7d62d62-baad-11e7-8d19-3bc63fa2d6dd.png)
