### PR TITLE
Log messages with the same level as configured

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -84,7 +84,7 @@ pub fn print_log(level: LogLevel, message: fmt::Arguments, params: LogParameters
 
 #[macro_export]
 macro_rules! janus_log_enabled {
-    ($lvl:expr) => (($lvl as i32) < unsafe { $crate::debug::JANUS_LOG_LEVEL })
+    ($lvl:expr) => (($lvl as i32) <= unsafe { $crate::debug::JANUS_LOG_LEVEL })
 }
 
 #[macro_export]


### PR DESCRIPTION
Hello @mquander, your new log abstractions are awesome! 👍 

But it seems like there is a little bug with a log level.
If have `VERB` level configured and use `janus_verb!` a message isn't logged.
I guess it is because we now have `<` comparison thought previously [it was](https://github.com/mozilla/janus-plugin-rs/commit/c7dd9dc867ebc3dfb4288423161309fa708fbf48#diff-dc325dec4dded4087051c453b51e6875L59) `<=`.