### PR TITLE
Remove cstr-macro dependency for janus-plugin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ members = ["janus-plugin-sys", "jansson-sys"]
 bitflags = "1.0.0"
 chrono = "0.4"
 colored = "1.5"
-cstr-macro = "0.1"
 glib-sys = "0.4"
 libc = "0.2"
 serde = "1.0"


### PR DESCRIPTION
Hello @mquander,

In [d635e60](https://github.com/mozilla/janus-plugin-rs/commit/d635e6018fd1744ea8dd4ad7626fe51f96532959) we stopped using `cstr-macro` crate and added our own `c_str!` macro.
It seems like `janus-plugin` crate is no longer depends on `cstr-macro` and it could be removed from `Cargo.toml`.

What do you think?