### PR TITLE
Leave plugin API version up to the plugin code

### DIFF
--- a/janus-plugin-sys/src/lib.rs
+++ b/janus-plugin-sys/src/lib.rs
@@ -9,12 +9,6 @@ use std::os::raw::{c_char, c_int, c_void};
 pub mod rtcp;
 pub mod sdp;
 
-#[cfg(not(feature="refcount"))]
-pub const JANUS_PLUGIN_API_VERSION: c_int = 8;
-
-#[cfg(feature="refcount")]
-pub const JANUS_PLUGIN_API_VERSION: c_int = 9;
-
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum janus_plugin_result_type {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@ extern crate serde;
 
 pub use debug::LogLevel;
 pub use debug::log;
-pub use ffi::JANUS_PLUGIN_API_VERSION as API_VERSION;
 pub use ffi::janus_callbacks as PluginCallbacks;
 pub use ffi::janus_plugin as Plugin;
 pub use ffi::janus_plugin_result as RawPluginResult;
@@ -126,6 +125,7 @@ unsafe impl Send for PluginResult {}
 #[derive(Debug)]
 /// Represents metadata about this plugin which Janus can query at runtime.
 pub struct PluginMetadata<'pl> {
+    pub api_version: c_int,
     pub version: c_int,
     pub version_str: &'pl CStr,
     pub description: &'pl CStr,
@@ -139,7 +139,7 @@ pub struct PluginMetadata<'pl> {
 #[macro_export]
 macro_rules! build_plugin {
     ($md:expr, $($cb:ident),*) => {{
-        extern "C" fn get_api_compatibility() -> c_int { $crate::API_VERSION }
+        extern "C" fn get_api_compatibility() -> c_int { $md.api_version }
         extern "C" fn get_version() -> c_int { $md.version }
         extern "C" fn get_version_string() -> *const c_char { $md.version_str.as_ptr() }
         extern "C" fn get_description() -> *const c_char { $md.description.as_ptr() }


### PR DESCRIPTION
There are more semantics tied to the plugin version than just the stuff inside this library, so it's not reasonable for this library to dictate to the plugin code what API version it must be.