### PR TITLE
Pass sort flag to Jansson in test

### DIFF
--- a/jansson-sys/src/lib.rs
+++ b/jansson-sys/src/lib.rs
@@ -157,7 +157,7 @@ mod tests {
             json_array_insert_new(ys, 1, json_integer(2));
             json_object_set_new(x, cstr!("g"), ys);
             let json = r#"{"a": "alpha", "b": true, "c": false, "d": 42, "e": 1.25, "f": null, "g": [1, 2, 3]}"#;
-            assert_eq!(json, CStr::from_ptr(json_dumps(x, 0)).to_str().unwrap());
+            assert_eq!(json, CStr::from_ptr(json_dumps(x, 0x80)).to_str().unwrap());
         }
     }
 

--- a/src/jansson.rs
+++ b/src/jansson.rs
@@ -138,7 +138,7 @@ mod tests {
     fn round_trip() {
         let json = r#"{"a": "alpha", "b": true, "c": false, "d": 42, "e": 1.25, "f": null, "g": [1, 2, 3]}"#;
         let result = JanssonValue::from_str(json, JanssonDecodingFlags::empty()).unwrap();
-        assert_eq!(json, result.to_libcstring(JanssonEncodingFlags::empty()).to_str().unwrap());
+        assert_eq!(json, result.to_libcstring(JanssonEncodingFlags::JSON_SORT_KEYS).to_str().unwrap());
     }
 
     #[test]


### PR DESCRIPTION
I guess this was probably always indeterministic. It's probably nicer to expose the Jansson flags as globals in the FFI, but that can wait for a moment.