### PR TITLE
Kill support for old Janus non-refcount stuff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,6 @@ description = "Library for creating plugins for Janus, the WebRTC gateway."
 repository = "https://github.com/mozilla/janus-plugin-rs"
 license = "MPL-2.0"
 
-[features]
-default = []
-refcount = ["janus-plugin-sys/refcount"] # compatible with the Janus refcount branch rather than stable branch
-
 [workspace]
 members = ["janus-plugin-sys", "jansson-sys"]
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,6 @@ Library for creating Rust plugins and event handlers for [Janus](https://janus.c
 janus-plugin = "0.11.1"
 ```
 
-If you want to build a version compatible with Janus >= 0.3 (which is more recent than e.g. Ubuntu's version), then use the `refcount` feature:
-
-``` toml
-[dependencies]
-janus-plugin = { version = "0.11.1", features = ["refcount"] }
-```
-
-
 ## Building
 
 Requires the [Jansson](http://www.digip.org/jansson/) native library (Ubuntu: `libjansson-dev`) to link against; tested as compatible with versions >= 2.5.

--- a/janus-plugin-sys/Cargo.toml
+++ b/janus-plugin-sys/Cargo.toml
@@ -6,10 +6,6 @@ description = "Native bindings to the Janus plugin API."
 repository = "https://github.com/mozilla/janus-plugin-rs"
 license = "MPL-2.0"
 
-[features]
-default = []
-refcount = [] # compatible with the Janus refcount branch rather than stable branch
-
 [dependencies]
 glib-sys = "0.4"
 jansson-sys = { path = "../jansson-sys", version = "0.1.0" }

--- a/janus-plugin-sys/src/lib.rs
+++ b/janus-plugin-sys/src/lib.rs
@@ -10,7 +10,6 @@ pub mod events;
 pub mod rtcp;
 pub mod sdp;
 
-#[cfg(feature="refcount")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct janus_refcount {
@@ -26,6 +25,5 @@ extern "C" {
     pub fn janus_get_api_error(error: c_int) -> *const c_char;
     pub fn janus_vprintf(format: *const c_char, ...);
 
-    #[cfg(feature="refcount")]
     pub static refcount_debug: c_int;
 }

--- a/janus-plugin-sys/src/plugin.rs
+++ b/janus-plugin-sys/src/plugin.rs
@@ -28,17 +28,6 @@ pub enum janus_plugin_result_type {
     JANUS_PLUGIN_OK_WAIT = 1,
 }
 
-#[cfg(not(feature="refcount"))]
-#[repr(C)]
-#[derive(Debug)]
-pub struct janus_plugin_session {
-    pub gateway_handle: *mut c_void,
-    pub plugin_handle: *mut c_void,
-    pub stopped_bitfield: u8, // todo: clean this up
-    pub __padding: [u8; 7usize],
-}
-
-#[cfg(feature="refcount")]
 #[repr(C)]
 #[derive(Debug)]
 pub struct janus_plugin_session {

--- a/janus-plugin-sys/src/sdp.rs
+++ b/janus-plugin-sys/src/sdp.rs
@@ -95,10 +95,5 @@ extern "C" {
     pub fn janus_sdp_get_codec_pt(sdp: *mut janus_sdp, codec: *const c_char) -> c_int;
     pub fn janus_sdp_get_codec_name(sdp: *mut janus_sdp, pt: c_int) -> *const c_char;
     pub fn janus_sdp_get_codec_rtpmap(codec: *const c_char) -> *const c_char;
-
-    #[cfg(not(feature="refcount"))]
-    pub fn janus_sdp_free(sdp: *mut janus_sdp);
-
-    #[cfg(feature="refcount")]
     pub fn janus_sdp_destroy(sdp: *mut janus_sdp);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,6 @@ pub mod sdp;
 pub mod session;
 pub mod jansson;
 pub mod utils;
-
-#[cfg(feature="refcount")]
 pub mod refcount;
 
 bitflags! {

--- a/src/refcount.rs
+++ b/src/refcount.rs
@@ -5,7 +5,6 @@ use std::ffi::CString;
 pub use ffi::janus_refcount as ReferenceCount;
 
 /// Atomically increment the given reference count by 1.
-#[cfg(feature="refcount")]
 pub fn increase(refcount: &ReferenceCount) {
     let field = &refcount.count;
     unsafe {
@@ -18,7 +17,6 @@ pub fn increase(refcount: &ReferenceCount) {
 }
 
 /// Atomically decrement the given reference count by 1. If it's 0, call free.
-#[cfg(feature="refcount")]
 pub fn decrease(refcount: &ReferenceCount) {
     let field = &refcount.count;
     unsafe {

--- a/src/sdp.rs
+++ b/src/sdp.rs
@@ -255,9 +255,6 @@ impl Deref for Sdp {
 impl Drop for Sdp {
     fn drop(&mut self) {
         unsafe {
-            #[cfg(not(feature="refcount"))]
-            ffi::sdp::janus_sdp_free(self.ptr);
-            #[cfg(feature="refcount")]
             ffi::sdp::janus_sdp_destroy(self.ptr);
         }
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -81,7 +81,6 @@ impl<T> Deref for SessionWrapper<T> {
     }
 }
 
-#[cfg(feature="refcount")]
 impl<T> Drop for SessionWrapper<T> {
     fn drop(&mut self) {
         unsafe {
@@ -99,7 +98,7 @@ unsafe impl<T: Sync> Sync for SessionWrapper<T> {}
 unsafe impl<T: Send> Send for SessionWrapper<T> {}
 
 // todo: port to refcount branch
-#[cfg(not(feature="refcount"))]
+/*
 #[cfg(test)]
 mod tests {
 
@@ -122,3 +121,4 @@ mod tests {
         assert_eq!(unsafe { SessionWrapper::<State>::from_ptr(ptr).unwrap().state.0 }, 42);
     }
 }
+*/


### PR DESCRIPTION
This is useless anymore since the Janus refcount code has been master for quite a while now.