### PR TITLE
Rust 2018 compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "janus-plugin"
 version = "0.11.1"
+edition = "2018"
 authors = ["Marshall Quander <marshall@quander.me>"]
 description = "Library for creating plugins for Janus, the WebRTC gateway."
 repository = "https://github.com/mozilla/janus-plugin-rs"

--- a/jansson-sys/Cargo.toml
+++ b/jansson-sys/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "jansson-sys"
 version = "0.1.0"
+edition = "2018"
 authors = ["Marshall Quander <marshall@quander.me>"]
 description = "Native bindings for Jansson, the C JSON library."
 repository = "https://github.com/mozilla/janus-plugin-rs"

--- a/jansson-sys/src/lib.rs
+++ b/jansson-sys/src/lib.rs
@@ -131,8 +131,7 @@ pub unsafe fn json_decref(json: *mut json_t) {
 }
 
 #[cfg(test)]
-#[macro_use]
-extern crate cstr_macro;
+use cstr_macro::cstr;
 
 #[cfg(test)]
 mod tests {

--- a/janus-plugin-sys/Cargo.toml
+++ b/janus-plugin-sys/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "janus-plugin-sys"
 version = "0.6.0"
+edition = "2018"
 authors = ["Marshall Quander <marshall@quander.me>"]
 description = "Native bindings to the Janus plugin API."
 repository = "https://github.com/mozilla/janus-plugin-rs"

--- a/janus-plugin-sys/src/lib.rs
+++ b/janus-plugin-sys/src/lib.rs
@@ -1,8 +1,6 @@
 #![allow(non_camel_case_types)]
 #![deny(missing_debug_implementations)]
 
-extern crate glib_sys;
-extern crate jansson_sys;
 use std::os::raw::{c_char, c_int};
 
 pub mod plugin;

--- a/janus-plugin-sys/src/plugin.rs
+++ b/janus-plugin-sys/src/plugin.rs
@@ -34,7 +34,7 @@ pub struct janus_plugin_session {
     pub gateway_handle: *mut c_void,
     pub plugin_handle: *mut c_void,
     pub stopped: c_int,
-    pub ref_: ::janus_refcount,
+    pub ref_: crate::janus_refcount,
 }
 
 #[repr(C)]

--- a/janus-plugin-sys/src/rtcp.rs
+++ b/janus-plugin-sys/src/rtcp.rs
@@ -1,6 +1,6 @@
 #![allow(non_camel_case_types)]
 
-use super::glib_sys::{gboolean, GSList};
+use glib_sys::{gboolean, GSList};
 use std::os::raw::{c_char, c_int, c_uint};
 
 extern "C" {

--- a/janus-plugin-sys/src/sdp.rs
+++ b/janus-plugin-sys/src/sdp.rs
@@ -1,6 +1,6 @@
 #![allow(non_camel_case_types)]
 
-use super::glib_sys::{gboolean, GList};
+use glib_sys::{gboolean, GList};
 use std::os::raw::{c_char, c_int, c_long, c_short, c_ulong};
 
 pub type guint16 = c_short;

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,11 +1,8 @@
 /// Utilities for writing messages to the Janus log.
-extern crate chrono;
-extern crate colored;
-
 pub use super::ffi::janus_log_level as JANUS_LOG_LEVEL;
-use self::chrono::{DateTime, Local};
-use self::colored::{Color, Colorize};
-use super::ffi;
+use chrono::{DateTime, Local};
+use colored::{Color, Colorize};
+use janus_plugin_sys as ffi;
 use std::ffi::CString;
 use std::fmt::Write;
 use std::fmt;
@@ -136,7 +133,7 @@ macro_rules! janus_dbg {
 mod tests {
 
     use super::*;
-    use super::chrono::TimeZone;
+    use chrono::TimeZone;
 
     fn fixed_clock(year: i32, month: u32, day: u32, hour: u32, min: u32, sec: u32) -> DateTime<Local> {
         Local.ymd(year, month, day).and_hms(hour, min, sec)

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,11 +1,11 @@
 /// Utilities for writing messages to the Janus log.
-pub use super::ffi::janus_log_level as JANUS_LOG_LEVEL;
 use chrono::{DateTime, Local};
 use colored::{Color, Colorize};
-use janus_plugin_sys as ffi;
 use std::ffi::CString;
 use std::fmt::Write;
 use std::fmt;
+use janus_plugin_sys as ffi;
+pub use ffi::janus_log_level as JANUS_LOG_LEVEL;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 /// A Janus log level. Lower is more severe.

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -88,7 +88,7 @@ macro_rules! janus_log_enabled {
 macro_rules! janus_log {
     ($lvl:expr, $($arg:tt)+) => ({
         let lvl = $lvl;
-        if janus_log_enabled!(lvl) {
+        if $crate::janus_log_enabled!(lvl) {
             $crate::debug::log(lvl, format_args!($($arg)+), $crate::debug::LogParameters::default())
         }
     })
@@ -96,37 +96,37 @@ macro_rules! janus_log {
 
 #[macro_export]
 macro_rules! janus_fatal {
-    ($($arg:tt)+) => (janus_log!($crate::debug::LogLevel::Fatal, $($arg)+))
+    ($($arg:tt)+) => ($crate::janus_log!($crate::debug::LogLevel::Fatal, $($arg)+))
 }
 
 #[macro_export]
 macro_rules! janus_err {
-    ($($arg:tt)+) => (janus_log!($crate::debug::LogLevel::Err, $($arg)+))
+    ($($arg:tt)+) => ($crate::janus_log!($crate::debug::LogLevel::Err, $($arg)+))
 }
 
 #[macro_export]
 macro_rules! janus_warn {
-    ($($arg:tt)+) => (janus_log!($crate::debug::LogLevel::Warn, $($arg)+))
+    ($($arg:tt)+) => ($crate::janus_log!($crate::debug::LogLevel::Warn, $($arg)+))
 }
 
 #[macro_export]
 macro_rules! janus_info {
-    ($($arg:tt)+) => (janus_log!($crate::debug::LogLevel::Info, $($arg)+))
+    ($($arg:tt)+) => ($crate::janus_log!($crate::debug::LogLevel::Info, $($arg)+))
 }
 
 #[macro_export]
 macro_rules! janus_verb {
-    ($($arg:tt)+) => (janus_log!($crate::debug::LogLevel::Verb, $($arg)+))
+    ($($arg:tt)+) => ($crate::janus_log!($crate::debug::LogLevel::Verb, $($arg)+))
 }
 
 #[macro_export]
 macro_rules! janus_huge {
-    ($($arg:tt)+) => (janus_log!($crate::debug::LogLevel::Huge, $($arg)+))
+    ($($arg:tt)+) => ($crate::janus_log!($crate::debug::LogLevel::Huge, $($arg)+))
 }
 
 #[macro_export]
 macro_rules! janus_dbg {
-    ($($arg:tt)+) => (janus_log!($crate::debug::LogLevel::Dbg, $($arg)+))
+    ($($arg:tt)+) => ($crate::janus_log!($crate::debug::LogLevel::Dbg, $($arg)+))
 }
 
 #[cfg(test)]

--- a/src/jansson.rs
+++ b/src/jansson.rs
@@ -1,5 +1,6 @@
 /// Utilities to work with Jansson JSON values, which are exposed in the Janus plugin API.
 
+use bitflags::bitflags;
 use jansson_sys;
 use std::error::Error;
 use std::fmt;
@@ -9,7 +10,6 @@ use std::ops::Deref;
 use std::slice;
 use std::str;
 use crate::utils::LibcString;
-use bitflags::bitflags;
 
 /// A pointer to a raw Jansson value struct.
 pub type RawJanssonValue = jansson_sys::json_t;

--- a/src/jansson.rs
+++ b/src/jansson.rs
@@ -1,5 +1,4 @@
 /// Utilities to work with Jansson JSON values, which are exposed in the Janus plugin API.
-extern crate libc;
 
 use jansson_sys;
 use std::error::Error;
@@ -9,7 +8,8 @@ use std::mem::MaybeUninit;
 use std::ops::Deref;
 use std::slice;
 use std::str;
-use utils::LibcString;
+use crate::utils::LibcString;
+use bitflags::bitflags;
 
 /// A pointer to a raw Jansson value struct.
 pub type RawJanssonValue = jansson_sys::json_t;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,11 @@
 #![deny(missing_debug_implementations)]
 
-#[macro_use]
-extern crate bitflags;
-extern crate jansson_sys;
-extern crate janus_plugin_sys as ffi;
-extern crate glib_sys as glib;
-extern crate libc;
-extern crate serde;
-
+use janus_plugin_sys as ffi;
+use glib_sys as glib;
+use bitflags::bitflags;
 pub use debug::LogLevel;
 pub use debug::log;
-pub use jansson::{JanssonDecodingFlags, JanssonEncodingFlags, JanssonValue, RawJanssonValue};
+pub use crate::jansson::{JanssonDecodingFlags, JanssonEncodingFlags, JanssonValue, RawJanssonValue};
 pub use session::SessionWrapper;
 pub use ffi::events::janus_eventhandler as EventHandler;
 pub use ffi::plugin::janus_callbacks as PluginCallbacks;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![deny(missing_debug_implementations)]
 
 use janus_plugin_sys as ffi;
-use glib_sys as glib;
 use bitflags::bitflags;
 pub use debug::LogLevel;
 pub use debug::log;

--- a/src/refcount.rs
+++ b/src/refcount.rs
@@ -1,6 +1,6 @@
 /// Utilities for working with Janus reference counts.
-use super::ffi;
-use super::glib;
+use glib_sys;
+use janus_plugin_sys as ffi;
 use std::ffi::CString;
 pub use ffi::janus_refcount as ReferenceCount;
 
@@ -12,7 +12,7 @@ pub fn increase(refcount: &ReferenceCount) {
             let msg = CString::new(format!("[rust:increase] {:p} ({:?})\n", refcount, field + 1)).unwrap();
             ffi::janus_vprintf(msg.as_ptr());
         }
-        glib::g_atomic_int_inc(field as *const _ as *mut _);
+        glib_sys::g_atomic_int_inc(field as *const _ as *mut _);
     }
 }
 
@@ -24,7 +24,7 @@ pub fn decrease(refcount: &ReferenceCount) {
             let msg = CString::new(format!("[rust:decrease] {:p} ({:?})\n", refcount, field - 1)).unwrap();
             ffi::janus_vprintf(msg.as_ptr());
         }
-        if glib::g_atomic_int_dec_and_test(field as *const _ as *mut _) == 1 {
+        if glib_sys::g_atomic_int_dec_and_test(field as *const _ as *mut _) == 1 {
             (refcount.free)(refcount);
         }
     }

--- a/src/rtcp.rs
+++ b/src/rtcp.rs
@@ -5,7 +5,7 @@
 /// <https://tools.ietf.org/html/rfc5104> (definition of FIR, others)
 /// <https://tools.ietf.org/html/draft-alvestrand-rmcat-remb-03> (definition of REMB)
 
-use super::ffi;
+use janus_plugin_sys as ffi;
 
 /// Returns whether this RTCP packet is a FIR packet.
 pub fn has_fir(packet: &[i8]) -> bool {

--- a/src/sdp.rs
+++ b/src/sdp.rs
@@ -1,8 +1,8 @@
 /// Utilities to write SDP offers and answers using Janus's SDP parsing machinery.
 
-use janus_plugin_sys as ffi;
-use glib_sys as glib;
+use glib_sys;
 use libc;
+use janus_plugin_sys as ffi;
 use serde::de::{self, Deserialize, Deserializer, Unexpected, Visitor};
 use serde::ser::{Serialize, Serializer};
 pub use ffi::sdp::janus_sdp_generate_answer as generate_answer;
@@ -171,7 +171,7 @@ impl Sdp {
         for (_media, m_lines) in self.get_mlines() {
             unsafe {
                 for m_line in m_lines {
-                    if !glib::g_list_find(m_line.ptypes, pt as *const _).is_null() {
+                    if !glib_sys::g_list_find(m_line.ptypes, pt as *const _).is_null() {
                         let attr = ffi::sdp::janus_sdp_attribute_create(name.as_ptr(), contents.as_ptr());
                         ffi::sdp::janus_sdp_attribute_add_to_mline(m_line as *mut _, attr as *mut _);
                     }
@@ -189,10 +189,10 @@ impl Sdp {
             unsafe {
                 for m_line in m_lines {
                     // 1. replace the payload type ID in this media line's payload type list
-                    if !glib::g_list_find(m_line.ptypes, from as *const _).is_null() {
+                    if !glib_sys::g_list_find(m_line.ptypes, from as *const _).is_null() {
                         // payload type data in the list is cast to pointers
-                        m_line.ptypes = glib::g_list_remove(m_line.ptypes, from as *const _);
-                        m_line.ptypes = glib::g_list_prepend(m_line.ptypes, to as *mut _);
+                        m_line.ptypes = glib_sys::g_list_remove(m_line.ptypes, from as *const _);
+                        m_line.ptypes = glib_sys::g_list_prepend(m_line.ptypes, to as *mut _);
                     }
                     // 2. rewrite the values of attribute lines with the old payload type to have the new payload type
                     let mut attr_node = m_line.attributes;
@@ -209,8 +209,8 @@ impl Sdp {
                                 // value string is copied into the attribute
                                 let new_val = CString::new(value.replacen(&from_pt_string, &to_pt_string, 1)).unwrap();
                                 let new_attr = ffi::sdp::janus_sdp_attribute_create(attr.name, new_val.as_ptr());
-                                m_line.attributes = glib::g_list_prepend(m_line.attributes, new_attr as *mut _);
-                                m_line.attributes = glib::g_list_delete_link(m_line.attributes, attr_node);
+                                m_line.attributes = glib_sys::g_list_prepend(m_line.attributes, new_attr as *mut _);
+                                m_line.attributes = glib_sys::g_list_delete_link(m_line.attributes, attr_node);
                                 ffi::sdp::janus_sdp_attribute_destroy(data);
                             }
                         }

--- a/src/sdp.rs
+++ b/src/sdp.rs
@@ -1,10 +1,10 @@
 /// Utilities to write SDP offers and answers using Janus's SDP parsing machinery.
 
-use super::ffi;
-use super::glib;
-use super::libc;
-use super::serde::de::{self, Deserialize, Deserializer, Unexpected, Visitor};
-use super::serde::ser::{Serialize, Serializer};
+use janus_plugin_sys as ffi;
+use glib_sys as glib;
+use libc;
+use serde::de::{self, Deserialize, Deserializer, Unexpected, Visitor};
+use serde::ser::{Serialize, Serializer};
 pub use ffi::sdp::janus_sdp_generate_answer as generate_answer;
 pub use ffi::sdp::janus_sdp_generate_offer as generate_offer;
 use std::collections::HashMap;
@@ -13,7 +13,7 @@ use std::fmt;
 use std::ffi::{CStr, CString};
 use std::ops::Deref;
 use std::str;
-use utils::GLibString;
+use crate::utils::GLibString;
 
 pub type RawSdp = ffi::sdp::janus_sdp;
 pub type RawMLine = ffi::sdp::janus_sdp_mline;

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,5 +1,5 @@
 /// Utilities to make it easier to maintain Janus session state between plugin callbacks.
-use super::PluginSession;
+use crate::PluginSession;
 use std::error::Error;
 use std::hash::{Hash, Hasher};
 use std::fmt;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,8 @@
 /// Wrapper types and helpers for working with the Janus FFI layer.
 
-use super::glib;
-use super::libc;
-use super::serde::ser::{self, Serialize, Serializer};
+use glib_sys as glib;
+use libc;
+use serde::ser::{self, Serialize, Serializer};
 use std::error::Error;
 use std::ffi::CStr;
 use std::ops::Deref;


### PR DESCRIPTION
This mostly entails cleaning up module imports. See https://doc.rust-lang.org/stable/edition-guide/rust-2018/module-system/path-clarity.html for more information.