### PR TITLE
Fix commented tests in sessions.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,8 @@ pub mod session;
 pub mod jansson;
 pub mod utils;
 pub mod refcount;
+#[cfg(test)]
+mod test_stubs;
 
 bitflags! {
     /// Flags that control which events an event handler receives.

--- a/src/session.rs
+++ b/src/session.rs
@@ -93,22 +93,25 @@ impl<T> Drop for SessionWrapper<T> {
 unsafe impl<T: Sync> Sync for SessionWrapper<T> {}
 unsafe impl<T: Send> Send for SessionWrapper<T> {}
 
-// todo: port to refcount branch
-/*
 #[cfg(test)]
 mod tests {
 
     use super::*;
+    use crate::refcount::ReferenceCount;
     use std::ptr;
 
     #[test]
     fn handle_round_trip() {
         struct State(i32);
+        extern "C" fn janus_session_free(_session_ref: *const ReferenceCount) {}
         let mut handle = PluginSession {
             gateway_handle: ptr::null_mut(),
             plugin_handle: ptr::null_mut(),
-            stopped_bitfield: 0,
-            __padding: Default::default(),
+            stopped: 0,
+            ref_: ReferenceCount {
+                count: 1,
+                free: janus_session_free,
+            },
         };
 
         let ptr = &mut handle as *mut _;
@@ -117,4 +120,3 @@ mod tests {
         assert_eq!(unsafe { SessionWrapper::<State>::from_ptr(ptr).unwrap().state.0 }, 42);
     }
 }
-*/

--- a/src/test_stubs.rs
+++ b/src/test_stubs.rs
@@ -1,0 +1,12 @@
+/// This modules defines stubs for functions from janus-plugin-sys crate to enable linking when
+/// compiling for running unit tests.
+use libc::c_void;
+use std::os::raw::{c_char, c_int};
+
+// lib.rs
+
+#[no_mangle]
+pub static refcount_debug: c_int = 0;
+
+#[no_mangle]
+pub unsafe extern "C" fn janus_vprintf(_format: *const c_char, _args: *mut c_void) {}


### PR DESCRIPTION
While reading the code I saw this commented test with a todo. Reading janus-conference code and how they stubs the ffi functions, I wanted to give it a try here. The tests pass.
Thanks @feymartynov @Leonqn I learn a lot from you. :)