### PR TITLE
Add plugin API v16 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ janus-plugin = "0.13.0"
 
 ## Compatibility
 
-Currently compatible with Janus versions >= 0.10.9; Janus makes breaking changes relatively frequently to
+Currently compatible with Janus versions >= 0.11.6; Janus makes breaking changes relatively frequently to
 the plugin API, so expect this library to require updating and recompilation for plugins to continue to work with new
 Janus versions.
 
@@ -69,7 +69,7 @@ const PLUGIN: Plugin = build_plugin!(
     LibraryMetadata {
         // The Janus plugin API version. The version compiled into the plugin
         // must be identical to the version in the Janus which loads the plugin.
-        api_version: 15,
+        api_version: 16,
         // Incrementing plugin version number for your own use.
         version: 1,
         // Human-readable metadata which Janus can query.
@@ -94,4 +94,4 @@ Here are some projects which are using these bindings:
 
 * https://github.com/mozilla/janus-plugin-sfu
 * https://github.com/ivanovaleksey/janus-echotest-rs
-* https://github.com/netology-group/janus-conference/
+* https://github.com/foxford/janus-conference/

--- a/janus-plugin-sys/src/plugin.rs
+++ b/janus-plugin-sys/src/plugin.rs
@@ -21,6 +21,7 @@ pub struct janus_callbacks {
     pub end_session: extern "C" fn(handle: *mut janus_plugin_session),
     pub events_is_enabled: extern "C" fn() -> c_int,
     pub notify_event: extern "C" fn(plugin: *mut janus_plugin, handle: *mut janus_plugin_session, event: *mut json_t),
+    pub auth_is_signed: extern "C" fn() -> gboolean,
     pub auth_is_signature_valid: extern "C" fn(plugin: *mut janus_plugin, token: *const c_char) -> gboolean,
     pub auth_signature_contains: extern "C" fn(plugin: *mut janus_plugin, token: *const c_char, descriptor: *const c_char) -> gboolean,
 }


### PR DESCRIPTION
Add auth_is_signed function in janus_callbacks struct required by api version 16 since janus 0.11.6

The api change was introduced in this janus commit
https://github.com/meetecho/janus-gateway/commit/f9906da03e011d6ac457d49a3b5473c320b01e6e